### PR TITLE
refactored cancel event business

### DIFF
--- a/src/main/java/com/pinkpony/controller/EventRestController.java
+++ b/src/main/java/com/pinkpony/controller/EventRestController.java
@@ -2,6 +2,7 @@ package com.pinkpony.controller;
 
 import com.pinkpony.model.Event;
 import com.pinkpony.repository.EventRepository;
+import com.pinkpony.service.EventService;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.data.rest.webmvc.RepositoryRestController;
 import org.springframework.hateoas.Resource;
@@ -14,25 +15,14 @@ import java.util.Map;
 @RepositoryRestController
 public class EventRestController {
 
-   @Autowired
-   private EventRepository eventRepository;
+
+    @Autowired
+    EventService eventService;
 
     @RequestMapping(value="/events/{eventId}", method = RequestMethod.PATCH)
     public @ResponseBody ResponseEntity<?> cancelEvent(@PathVariable Long eventId,
-                                                      @RequestBody Map<String, String> eventMap) {Event originalEvent = eventRepository.findOne(eventId);
-        Resource<Event> resource = new Resource<Event>(originalEvent);
-
-        if (! originalEvent.getOrganizer().equals(eventMap.get("organizer"))) {
-            return ResponseEntity.status(HttpStatus.FORBIDDEN).body(resource);
-        }
-
-        String cancellationStatus = eventMap.get("cancelled").toLowerCase();
-        if (! (cancellationStatus.equals("false") || cancellationStatus.equals("true"))){
-           return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(resource);
-        }
-
-        originalEvent.setCancelled(Boolean.parseBoolean(eventMap.get("cancelled")));
-        eventRepository.save(originalEvent);
-        return ResponseEntity.ok(resource);
+                                                      @RequestBody Map<String, String> eventMap) {
+        return eventService.handleEventPUT(eventId, eventMap);
    }
+
 }

--- a/src/main/java/com/pinkpony/service/EventService.java
+++ b/src/main/java/com/pinkpony/service/EventService.java
@@ -1,0 +1,40 @@
+package com.pinkpony.service;
+
+
+import com.pinkpony.model.Event;
+import com.pinkpony.repository.EventRepository;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.Scope;
+import org.springframework.hateoas.Resource;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Service;
+
+import java.util.Map;
+
+@Service
+public class EventService {
+
+    @Autowired
+    EventRepository eventRepository;
+
+    public ResponseEntity<?> handleEventPUT(Long eventId, Map<String, String> eventMap) {
+        Event originalEvent = eventRepository.findOne(eventId);
+        Resource<Event> resource = new Resource<Event>(originalEvent);
+
+        if (! originalEvent.getOrganizer().equals(eventMap.get("organizer"))) {
+            return ResponseEntity.status(HttpStatus.FORBIDDEN).body(resource);
+        }
+
+        String cancellationStatus = eventMap.get("cancelled").toLowerCase();
+        if (! (cancellationStatus.equals("false") || cancellationStatus.equals("true"))){
+            return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(resource);
+        }
+
+        originalEvent.setCancelled(Boolean.parseBoolean(eventMap.get("cancelled")));
+        eventRepository.save(originalEvent);
+        return ResponseEntity.ok(resource);
+    }
+
+
+}


### PR DESCRIPTION
Moved the business logic around organiser permissions and cancellation of an event from the EventRestController into the service layer.

[#116421329] 