### PR TITLE
Clean up GET /events/{id} response

### DIFF
--- a/src/main/java/com/pinkpony/model/CalendarEvent.java
+++ b/src/main/java/com/pinkpony/model/CalendarEvent.java
@@ -50,8 +50,10 @@ public class CalendarEvent implements Serializable {
         this.cancelled = cancelled;
     }
 
-    public String getFormattedEventDateTime() {
-        return dateFormat.format(getCalendarEventDateTime());
+    public String getEventDateTimeAsUTCString() {
+        DateFormat outputFormat = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ssZ");
+        outputFormat.setTimeZone(TimeZone.getTimeZone("UTC"));
+        return outputFormat.format(getCalendarEventDateTime());
     }
 
     public String getCalendarEventDateTimeString() {
@@ -108,5 +110,14 @@ public class CalendarEvent implements Serializable {
 
     public void setName(String name) {
         this.name = name;
+    }
+
+    public void addRsvp(Rsvp rsvp) {
+        rsvp.calendarEvent = this;
+        rsvps.add(rsvp);
+    }
+
+    public List<Rsvp> getRsvps() {
+        return rsvps;
     }
 }

--- a/src/main/java/com/pinkpony/model/CalendarEventProjection.java
+++ b/src/main/java/com/pinkpony/model/CalendarEventProjection.java
@@ -5,14 +5,14 @@ import org.springframework.data.rest.core.config.Projection;
 
 import java.util.List;
 
-@Projection(name = "inlineRsvp", types = CalendarEvent.class)
+@Projection(name = "inlineRsvps", types = CalendarEvent.class)
 public interface CalendarEventProjection {
     String getName();
     String getDescription();
     String getUsername();
     String getVenue();
 
-    @Value("#{ target.getFormattedEventDateTime() }")
+    @Value("#{ target.getEventDateTimeAsUTCString() }")
     String getCalendarEventDateTime();
     Boolean getCancelled();
 

--- a/src/test/java/com/pinkpony/integration/PinkPonyIntegrationBase.java
+++ b/src/test/java/com/pinkpony/integration/PinkPonyIntegrationBase.java
@@ -55,6 +55,7 @@ abstract class PinkPonyIntegrationBase {
         rsvpRepository.deleteAll();
         calendarEventRepository.deleteAll();
         calendarEventDate = (new DateTime(DateTimeZone.forID("UTC")).plusDays(1).toDate());
+        calendarEventDateString = dateFormat.format(calendarEventDate);
         existingCalendarEvent = calendarEventRepository.save(makeCalendarEvent(calendarEventDate));
     }
 
@@ -63,18 +64,34 @@ abstract class PinkPonyIntegrationBase {
         newCalendarEvent.setName("Spring Boot Night");
         newCalendarEvent.setDescription("Wanna learn how to boot?");
         newCalendarEvent.setVenue("Arrowhead Lounge");
-        newCalendarEvent.setCalendarEventDateTime(date);
         newCalendarEvent.setUsername("Holly");
+
+        newCalendarEvent.setCalendarEventDateTime(date);
+        newCalendarEvent.setCalendarEventDateTimeString(toUTCString(date));
+
         return newCalendarEvent;
     }
 
-    public Rsvp createTestRsvp(String username, String response) {
+    public CalendarEvent addRsvp(CalendarEvent event, String response, String username) {
+        Rsvp rsvp = new Rsvp();
+        rsvp.setUsername(username);
+        rsvp.setResponse(response);
+        event.addRsvp(rsvp);
+        return calendarEventRepository.save(event);
+    }
+
+    public Rsvp createTestRsvp(String response, String username) {
         Rsvp rsvp = new Rsvp();
         rsvp.setUsername(username);
         rsvp.setResponse(response);
         rsvp.calendarEvent = existingCalendarEvent;
-        rsvpRepository.save(rsvp);
-        return rsvp;
+        return rsvpRepository.save(rsvp);
+    }
+
+    private String toUTCString(Date date) {
+        DateFormat outputFormat = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ssZ");
+        outputFormat.setTimeZone(TimeZone.getTimeZone("UTC"));
+        return outputFormat.format(date);
     }
 
 }

--- a/src/test/java/com/pinkpony/integration/RsvpTest.java
+++ b/src/test/java/com/pinkpony/integration/RsvpTest.java
@@ -68,13 +68,13 @@ public class RsvpTest extends PinkPonyIntegrationBase {
 
     @Test
     public void editRsvp() {
-        Rsvp testRsvp = createTestRsvp("Bobby", "yes");
+        Rsvp rsvp = createTestRsvp("Bobby", "yes");
 
         given().
                 contentType(ContentType.JSON).
                 request().body("{\"username\":\"Bobby\", \"response\":\"no\"}").
             when().
-                patch(String.format("/rsvps/%s", testRsvp.getId())).
+                patch(String.format("/rsvps/%s", rsvp.getId())).
             then().
                 statusCode(200).
                 body("response", equalTo("no")).

--- a/src/test/java/com/pinkpony/integration/UpcomingCalendarEventTest.java
+++ b/src/test/java/com/pinkpony/integration/UpcomingCalendarEventTest.java
@@ -1,32 +1,16 @@
 package com.pinkpony.integration;
 
-import com.jayway.restassured.RestAssured;
 import com.jayway.restassured.http.ContentType;
-import com.pinkpony.PinkPonyApplication;
 import com.pinkpony.model.CalendarEvent;
-import com.pinkpony.repository.CalendarEventRepository;
 import org.joda.time.DateTime;
 import org.joda.time.DateTimeZone;
-import org.junit.Before;
 import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.beans.factory.annotation.Value;
-import org.springframework.boot.test.IntegrationTest;
-import org.springframework.boot.test.SpringApplicationConfiguration;
-import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
-import org.springframework.test.context.web.WebAppConfiguration;
-
-import java.text.DateFormat;
-import java.text.SimpleDateFormat;
-import java.util.Date;
-import java.util.TimeZone;
 
 import static com.jayway.restassured.RestAssured.given;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.hasSize;
 
-public class UpcomingCalendarEventTest extends PinkPonyIntegrationBase{
+public class UpcomingCalendarEventTest extends PinkPonyIntegrationBase {
 
     private DateTime today = new DateTime(DateTimeZone.forID("UTC"));
     private DateTime yesterday = today.minusDays(1);

--- a/src/test/java/com/pinkpony/model/CalendarEventTest.java
+++ b/src/test/java/com/pinkpony/model/CalendarEventTest.java
@@ -1,0 +1,20 @@
+package com.pinkpony.model;
+
+import org.junit.Test;
+
+import static org.hamcrest.Matchers.hasItem;
+import static org.junit.Assert.assertThat;
+
+public class CalendarEventTest {
+
+    @Test
+    public void testAddRsvp() throws Exception {
+        CalendarEvent event = new CalendarEvent();
+        Rsvp rsvp = new Rsvp();
+        rsvp.setResponse("yes");
+        rsvp.setUsername("Hermione");
+        event.addRsvp(rsvp);
+
+        assertThat(event.getRsvps(), hasItem(rsvp));
+    }
+}


### PR DESCRIPTION
- Default a calendarEvent's datetime to output in UTC format
- A projection will embed RSVP summaries in the event payload

Finishes [#116507261]